### PR TITLE
Unified accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
 name = "academy-pow-runtime"
 version = "3.0.0"
 dependencies = [
+ "account",
  "async-trait",
  "fp-evm",
  "fp-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "account"
+version = "0.1.1"
+dependencies = [
+ "blake2-rfc",
+ "hex",
+ "impl-serde 0.3.2",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sha3",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-std",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +410,15 @@ name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
 
 [[package]]
 name = "arrayvec"
@@ -698,6 +727,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+dependencies = [
+ "arrayvec 0.4.12",
+ "constant_time_eq 0.1.5",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,7 +744,7 @@ checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -716,7 +755,7 @@ checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -729,7 +768,7 @@ dependencies = [
  "arrayvec 0.7.2",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -1117,6 +1156,12 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -1964,7 +2009,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
  "tiny-keccak",
 ]
@@ -1997,7 +2042,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "primitive-types",
  "scale-info",
  "uint",
@@ -2387,7 +2432,7 @@ version = "1.0.0-dev"
 source = "git+https://github.com/paritytech/frontier.git?branch=bar/polkadot-v0.9.42#a5a5e1e6ec08cd542a6084c310863150fb8841b1"
 dependencies = [
  "hex",
- "impl-serde",
+ "impl-serde 0.4.0",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
@@ -3246,6 +3291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
  "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4625,6 +4679,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5474,7 +5534,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
  "uint",
 ]
@@ -7948,7 +8008,7 @@ dependencies = [
  "futures",
  "hash-db 0.16.0",
  "hash256-std-hasher",
- "impl-serde",
+ "impl-serde 0.4.0",
  "lazy_static",
  "libsecp256k1",
  "log",
@@ -8257,7 +8317,7 @@ name = "sp-storage"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#569aae5341ea0c1d10426fa1ec13a36c0b64393b"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
@@ -8345,7 +8405,7 @@ name = "sp-version"
 version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#569aae5341ea0c1d10426fa1ec13a36c0b64393b"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
     'node',
     'runtime',
     'node/sha3pow',
+    'account',
 ]

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "account"
+edition = "2021"
+homepage = "https://moonbeam.network"
+license = "GPL-3.0-only"
+version = "0.1.1"
+
+[package.metadata.docs.rs]
+targets = [ "x86_64-unknown-linux-gnu" ]
+
+[dependencies]
+blake2-rfc = { version = "0.2.18", default-features = false, optional = true }
+hex = { version = "0.4.3", default-features = false }
+impl-serde = { version = "0.3.1", default-features = false }
+libsecp256k1 = { version = "0.7", default-features = false , features = [ "hmac" ] }
+log = { version = "0.4", default-features = false }
+serde = { version = "1.0.101", default-features = false, optional = true, features = [ "derive" ] }
+sha3 = { version = "0.10", default-features = false }
+
+# Substrate
+parity-scale-codec = {version = "3.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-runtime-interface = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+
+# I don't think we need this because it is already a full dependency.
+# Maybe fix this upstream in moonbeam too.
+# [dev-dependencies]
+# hex = { workspace = true }
+
+[features]
+default = [ "std" ]
+std = [
+	"full_crypto",
+	"hex/std",
+	"impl-serde/std",
+	"libsecp256k1/std",
+	"parity-scale-codec/std",
+	"serde/std",
+	"sha3/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]
+
+full_crypto = [
+	"blake2-rfc",
+	"sp-runtime-interface/disable_target_static_assertions",
+]

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -1,0 +1,243 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The Ethereum Signature implementation.
+//!
+//! It includes the Verify and IdentifyAccount traits for the AccountId20
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sha3::{Digest, Keccak256};
+use sp_core::{ecdsa, H160};
+
+#[cfg(feature = "std")]
+pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+//TODO Maybe this should be upstreamed into Frontier (And renamed accordingly) so that it can
+// be used in palletEVM as well. It may also need more traits such as AsRef, AsMut, etc like
+// AccountId32 has.
+
+/// The account type to be used in Moonbeam. It is a wrapper for 20 fixed bytes. We prefer to use
+/// a dedicated type to prevent using arbitrary 20 byte arrays were AccountIds are expected. With
+/// the introduction of the `scale-info` crate this benefit extends even to non-Rust tools like
+/// Polkadot JS.
+
+#[derive(
+	Eq, PartialEq, Copy, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Default, PartialOrd, Ord,
+)]
+pub struct AccountId20(pub [u8; 20]);
+
+#[cfg(feature = "std")]
+impl_serde::impl_fixed_hash_serde!(AccountId20, 20);
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for AccountId20 {
+	//TODO This is a pretty quck-n-dirty implementation. Perhaps we should add
+	// checksum casing here? I bet there is a crate for that.
+	// Maybe this one https://github.com/miguelmota/rust-eth-checksum
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{:?}", self.0)
+	}
+}
+
+impl core::fmt::Debug for AccountId20 {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		write!(f, "{:?}", H160(self.0))
+	}
+}
+
+impl From<[u8; 20]> for AccountId20 {
+	fn from(bytes: [u8; 20]) -> Self {
+		Self(bytes)
+	}
+}
+
+impl Into<[u8; 20]> for AccountId20 {
+	fn into(self) -> [u8; 20] {
+		self.0
+	}
+}
+
+impl From<[u8; 32]> for AccountId20 {
+	fn from(bytes: [u8; 32]) -> Self {
+		let mut buffer = [0u8; 20];
+		buffer.copy_from_slice(&bytes[..20]);
+		Self(buffer)
+	}
+}
+
+impl From<H160> for AccountId20 {
+	fn from(h160: H160) -> Self {
+		Self(h160.0)
+	}
+}
+
+impl Into<H160> for AccountId20 {
+	fn into(self) -> H160 {
+		H160(self.0)
+	}
+}
+
+#[cfg(feature = "std")]
+impl std::str::FromStr for AccountId20 {
+	type Err = &'static str;
+	fn from_str(input: &str) -> Result<Self, Self::Err> {
+		H160::from_str(input)
+			.map(Into::into)
+			.map_err(|_| "invalid hex address.")
+	}
+}
+
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Eq, PartialEq, Clone, Encode, Decode, sp_core::RuntimeDebug, TypeInfo)]
+pub struct EthereumSignature(ecdsa::Signature);
+
+impl From<ecdsa::Signature> for EthereumSignature {
+	fn from(x: ecdsa::Signature) -> Self {
+		EthereumSignature(x)
+	}
+}
+
+impl sp_runtime::traits::Verify for EthereumSignature {
+	type Signer = EthereumSigner;
+	fn verify<L: sp_runtime::traits::Lazy<[u8]>>(&self, mut msg: L, signer: &AccountId20) -> bool {
+		let mut m = [0u8; 32];
+		m.copy_from_slice(Keccak256::digest(msg.get()).as_slice());
+		match sp_io::crypto::secp256k1_ecdsa_recover(self.0.as_ref(), &m) {
+			Ok(pubkey) => {
+				AccountId20(H160::from_slice(&Keccak256::digest(&pubkey).as_slice()[12..32]).0)
+					== *signer
+			}
+			Err(sp_io::EcdsaVerifyError::BadRS) => {
+				log::error!(target: "evm", "Error recovering: Incorrect value of R or S");
+				false
+			}
+			Err(sp_io::EcdsaVerifyError::BadV) => {
+				log::error!(target: "evm", "Error recovering: Incorrect value of V");
+				false
+			}
+			Err(sp_io::EcdsaVerifyError::BadSignature) => {
+				log::error!(target: "evm", "Error recovering: Invalid signature");
+				false
+			}
+		}
+	}
+}
+
+/// Public key for an Ethereum / Moonbeam compatible account
+#[derive(
+	Eq, PartialEq, Ord, PartialOrd, Clone, Encode, Decode, sp_core::RuntimeDebug, TypeInfo,
+)]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+pub struct EthereumSigner([u8; 20]);
+
+impl sp_runtime::traits::IdentifyAccount for EthereumSigner {
+	type AccountId = AccountId20;
+	fn into_account(self) -> AccountId20 {
+		AccountId20(self.0)
+	}
+}
+
+impl From<[u8; 20]> for EthereumSigner {
+	fn from(x: [u8; 20]) -> Self {
+		EthereumSigner(x)
+	}
+}
+
+impl From<ecdsa::Public> for EthereumSigner {
+	fn from(x: ecdsa::Public) -> Self {
+		let decompressed = libsecp256k1::PublicKey::parse_slice(
+			&x.0,
+			Some(libsecp256k1::PublicKeyFormat::Compressed),
+		)
+		.expect("Wrong compressed public key provided")
+		.serialize();
+		let mut m = [0u8; 64];
+		m.copy_from_slice(&decompressed[1..65]);
+		let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
+		EthereumSigner(account.into())
+	}
+}
+
+impl From<libsecp256k1::PublicKey> for EthereumSigner {
+	fn from(x: libsecp256k1::PublicKey) -> Self {
+		let mut m = [0u8; 64];
+		m.copy_from_slice(&x.serialize()[1..65]);
+		let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
+		EthereumSigner(account.into())
+	}
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for EthereumSigner {
+	fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(fmt, "ethereum signature: {:?}", H160::from_slice(&self.0))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sp_core::{ecdsa, Pair, H256};
+	use sp_runtime::traits::IdentifyAccount;
+
+	#[test]
+	fn test_account_derivation_1() {
+		// Test from https://asecuritysite.com/encryption/ethadd
+		let secret_key =
+			hex::decode("502f97299c472b88754accd412b7c9a6062ef3186fba0c0388365e1edec24875")
+				.unwrap();
+		let mut expected_hex_account = [0u8; 20];
+		hex::decode_to_slice(
+			"976f8456e4e2034179b284a23c0e0c8f6d3da50c",
+			&mut expected_hex_account,
+		)
+		.expect("example data is 20 bytes of valid hex");
+
+		let public_key = ecdsa::Pair::from_seed_slice(&secret_key).unwrap().public();
+		let account: EthereumSigner = public_key.into();
+		let expected_account = AccountId20::from(expected_hex_account);
+		assert_eq!(account.into_account(), expected_account);
+	}
+	#[test]
+	fn test_account_derivation_2() {
+		// Test from https://asecuritysite.com/encryption/ethadd
+		let secret_key =
+			hex::decode("0f02ba4d7f83e59eaa32eae9c3c4d99b68ce76decade21cdab7ecce8f4aef81a")
+				.unwrap();
+		let mut expected_hex_account = [0u8; 20];
+		hex::decode_to_slice(
+			"420e9f260b40af7e49440cead3069f8e82a5230f",
+			&mut expected_hex_account,
+		)
+		.expect("example data is 20 bytes of valid hex");
+
+		let public_key = ecdsa::Pair::from_seed_slice(&secret_key).unwrap().public();
+		let account: EthereumSigner = public_key.into();
+		let expected_account = AccountId20::from(expected_hex_account);
+		assert_eq!(account.into_account(), expected_account);
+	}
+	#[test]
+	fn test_account_derivation_3() {
+		let m = hex::decode("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+			.unwrap();
+		let old = AccountId20(H160::from(H256::from_slice(Keccak256::digest(&m).as_slice())).0);
+		let new = AccountId20(H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]).0);
+		assert_eq!(new, old);
+	}
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,6 +10,7 @@ parity-scale-codec = {version = "3.1.2", default-features = false, features = ["
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
 serde = { version = '1.0.137', optional = true }
 async-trait = { version = '0.1.53', optional = true }
+account = { path = "../account", default-features = false }
 
 
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
@@ -61,6 +62,7 @@ substrate-wasm-builder = { default-features = false, git = "https://github.com/p
 [features]
 default = ['std']
 std = [
+    'account/std',
     'pallet-balances/std',
     'parity-scale-codec/std',
     'frame-executive/std',

--- a/runtime/src/address_mapping.rs
+++ b/runtime/src/address_mapping.rs
@@ -7,8 +7,6 @@
 //!
 //! WARNING! THIS PALLET IS INSECURE, DO NOT USE IT IN PRODUCTION!
 
-// Ensure we're `no_std` when compiling for Wasm.
-#![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;
 

--- a/runtime/src/block_author.rs
+++ b/runtime/src/block_author.rs
@@ -1,11 +1,8 @@
-//! This pallet allows block authors to self-identify by providing an sr25519 public key
-//!
-//! The included trait allows other pallets to fetch the author's account as long as the
-//! runtime's AccountId type can be created from an sr25519 public key.
+//! This pallet allows block authors to self-identify by providing an account ID
+//! The included trait allows other pallets to fetch the author's account.
 
 pub use pallet::*;
 use parity_scale_codec::{Decode, Encode};
-use sp_core::sr25519;
 use sp_inherents::{InherentData, InherentIdentifier, IsFatalError};
 use sp_runtime::RuntimeString;
 use sp_std::vec::Vec;
@@ -14,6 +11,8 @@ use sp_std::vec::Vec;
 pub mod pallet {
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
+
+    use crate::AccountId;
 
     use super::*;
 
@@ -34,16 +33,13 @@ pub mod pallet {
 
     /// Author of current block.
     #[pallet::storage]
-    pub type Author<T: Config> = StorageValue<_, sr25519::Public, OptionQuery>;
+    pub type Author<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
 
     #[pallet::call]
-    impl<T: Config> Pallet<T>
-    where
-        <T as frame_system::Config>::AccountId: From<sp_core::sr25519::Public>,
-    {
+    impl<T: Config> Pallet<T> {
         /// Inherent to set the author of a block
         #[pallet::weight(1_000_000)]
-        pub fn set_author(origin: OriginFor<T>, author: sr25519::Public) -> DispatchResult {
+        pub fn set_author(origin: OriginFor<T>, author: AccountId) -> DispatchResult {
             ensure_none(origin)?;
             ensure!(Author::<T>::get().is_none(), Error::<T>::AuthorAlreadySet);
 
@@ -71,10 +67,7 @@ pub mod pallet {
     }
 
     #[pallet::inherent]
-    impl<T: Config> ProvideInherent for Pallet<T>
-    where
-        <T as frame_system::Config>::AccountId: From<sp_core::sr25519::Public>,
-    {
+    impl<T: Config> ProvideInherent for Pallet<T> {
         type Call = Call<T>;
         type Error = InherentError;
         const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
@@ -94,7 +87,7 @@ pub mod pallet {
                 .expect("Gets and decodes authorship inherent data")?;
 
             // Decode the Vec<u8> into an actual author
-            let author = sr25519::Public::decode(&mut &author_raw[..])
+            let author = AccountId::decode(&mut &author_raw[..])
                 .expect("Decodes author raw inherent data");
 
             Some(Call::set_author { author })
@@ -107,22 +100,19 @@ pub mod pallet {
 }
 
 /// A trait to find the author (miner) of the block.
-pub trait BlockAuthor<AccountId: From<sr25519::Public>> {
+pub trait BlockAuthor<AccountId> {
     fn block_author() -> Option<AccountId>;
 }
 
-impl<AccountId: From<sr25519::Public>> BlockAuthor<AccountId> for () {
+impl<AccountId> BlockAuthor<AccountId> for () {
     fn block_author() -> Option<AccountId> {
         None
     }
 }
 
-impl<T: Config> BlockAuthor<T::AccountId> for Pallet<T>
-where
-    <T as frame_system::Config>::AccountId: From<sp_core::sr25519::Public>,
-{
+impl<T: Config> BlockAuthor<T::AccountId> for Pallet<T> {
     fn block_author() -> Option<T::AccountId> {
-        Author::<T>::get().map(|a| a.into())
+        Author::<T>::get()
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,7 +14,7 @@ use sp_std::prelude::*;
 use fp_evm::weight_per_gas;
 use fp_rpc::TransactionStatus;
 use pallet_ethereum::{PostLogContent, Transaction as EthereumTransaction};
-use pallet_evm::{Account as EVMAccount, FeeCalculator, Runner};
+use pallet_evm::{Account as EVMAccount, FeeCalculator, Runner, EnsureAddressSame, IdentityAddressMapping};
 use address_mapping::{EVMAddressMapping, EnsureAddressMapped};
 
 // A few exports that help ease life for downstream crates.
@@ -341,13 +341,13 @@ impl FindAuthor<H160> for FindAuthorMapped {
 }
 
 impl pallet_evm::Config for Runtime {
-    type FeeCalculator = BaseFee;
+    type FeeCalculator = ();
     type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
     type WeightPerGas = WeightPerGas;
     type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
-    type CallOrigin = EnsureAddressMapped<Runtime>;
-    type WithdrawOrigin = EnsureAddressMapped<Runtime>;
-    type AddressMapping = EVMAddressMapping<Runtime>;
+    type CallOrigin = EnsureAddressSame<Runtime>;
+    type WithdrawOrigin = EnsureAddressSame<Runtime>;
+    type AddressMapping = IdentityAddressMapping;
     type Currency = Balances;
     type RuntimeEvent = RuntimeEvent;
     type PrecompilesType = FrontierPrecompiles<Self>;


### PR DESCRIPTION
This PR attempts to bring in `AccountId20` as the account id in order to eliminate the need for the manual mapping entirely.

I believe I am close, but I have some very strange compile errors related to trait bounds.

I'm trying to get `cargo check -p academy-pow-runtime` to pass, and I'm pretty confident I can take it from there. But currently it fails with this (and several very similar errors).

```
  error[E0599]: the function or associated item `execute_block` exists for struct `Executive<Runtime, Block<Header<u32, BlakeTwo256>, UncheckedExtrinsic<..., ..., ..., ...>>, ..., ..., ...>`, but its trait bounds were not satisfied
     --> /home/joshy/ProgrammingProjects/Academy-PoW/runtime/src/lib.rs:554:24
      |
  554 |             Executive::execute_block(block)
      |                        ^^^^^^^^^^^^^ function or associated item cannot be called due to unsatisfied trait bounds
      |
     ::: /home/joshy/.cargo/git/checkouts/substrate-7e08433d4c370a21/569aae5/primitives/runtime/src/generic/unchecked_extrinsic.rs:44:1
      |
  44  | pub struct UncheckedExtrinsic<Address, Call, Signature, Extra>
      | -------------------------------------------------------------- doesn't satisfy `_: Checkable<ChainContext<Runtime>>`
      |
      = note: the full type name has been written to '/home/joshy/ProgrammingProjects/Academy-PoW/target/debug/wbuild/academy-pow-runtime/target/wasm32-unknown-unknown/release/deps/academy_pow_runtime-f440831b9db1ec60.long-type-15342852507686235652.txt'
      = note: the following trait bounds were not satisfied:
              `sp_runtime::generic::UncheckedExtrinsic<AccountId20, RuntimeCall, EthereumSignature, (CheckSpecVersion<Runtime>, CheckTxVersion<Runtime>, CheckGenesis<Runtime>, CheckEra<Runtime>, CheckNonce<Runtime>, CheckWeight<Runtime>)>: Checkable<ChainContext<Runtime>>`
```