### PR TITLE
Use `AccountId20` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "account"
+version = "0.1.1"
+dependencies = [
+ "blake2-rfc",
+ "hex",
+ "impl-serde 0.3.2",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sha3",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-std",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +392,15 @@ name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
 
 [[package]]
 name = "arrayvec"
@@ -668,6 +697,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+dependencies = [
+ "arrayvec 0.4.12",
+ "constant_time_eq 0.1.5",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,7 +714,7 @@ checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -686,7 +725,7 @@ checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -699,7 +738,7 @@ dependencies = [
  "arrayvec 0.7.2",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -1087,6 +1126,12 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -2876,6 +2921,15 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
@@ -4251,6 +4305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4953,7 +5013,7 @@ checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
  "uint",
 ]
@@ -7396,7 +7456,7 @@ dependencies = [
  "futures",
  "hash-db",
  "hash256-std-hasher",
- "impl-serde",
+ "impl-serde 0.4.0",
  "lazy_static",
  "libsecp256k1",
  "log",
@@ -7705,7 +7765,7 @@ name = "sp-storage"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#569aae5341ea0c1d10426fa1ec13a36c0b64393b"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
@@ -7793,7 +7853,7 @@ name = "sp-version"
 version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#569aae5341ea0c1d10426fa1ec13a36c0b64393b"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
 name = "academy-pow-runtime"
 version = "3.0.0"
 dependencies = [
+ "account",
  "async-trait",
  "frame-executive",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ name = "academy-pow"
 version = "3.0.0"
 dependencies = [
  "academy-pow-runtime",
+ "account",
  "clap",
  "futures",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "clap",
  "futures",
  "hex",
+ "hex-literal",
  "jsonrpsee",
  "log",
  "pallet-transaction-payment-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
     'node',
     'runtime',
     'node/sha3pow',
+    'account',
 ]

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "account"
+edition = "2021"
+homepage = "https://moonbeam.network"
+license = "GPL-3.0-only"
+version = "0.1.1"
+
+[package.metadata.docs.rs]
+targets = [ "x86_64-unknown-linux-gnu" ]
+
+[dependencies]
+blake2-rfc = { version = "0.2.18", default-features = false, optional = true }
+hex = { version = "0.4.3", default-features = false }
+impl-serde = { version = "0.3.1", default-features = false }
+libsecp256k1 = { version = "0.7", default-features = false , features = [ "hmac" ] }
+log = { version = "0.4", default-features = false }
+serde = { version = "1.0.101", default-features = false, optional = true, features = [ "derive" ] }
+sha3 = { version = "0.10", default-features = false }
+
+# Substrate
+parity-scale-codec = {version = "3.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-runtime-interface = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+
+# I don't think we need this because it is already a full dependency.
+# Maybe fix this upstream in moonbeam too.
+# [dev-dependencies]
+# hex = { workspace = true }
+
+[features]
+default = [ "std" ]
+std = [
+	"full_crypto",
+	"hex/std",
+	"impl-serde/std",
+	"libsecp256k1/std",
+	"parity-scale-codec/std",
+	"serde/std",
+	"sha3/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]
+
+full_crypto = [
+	"blake2-rfc",
+	"sp-runtime-interface/disable_target_static_assertions",
+]

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -1,0 +1,243 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The Ethereum Signature implementation.
+//!
+//! It includes the Verify and IdentifyAccount traits for the AccountId20
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sha3::{Digest, Keccak256};
+use sp_core::{ecdsa, H160};
+
+#[cfg(feature = "std")]
+pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+//TODO Maybe this should be upstreamed into Frontier (And renamed accordingly) so that it can
+// be used in palletEVM as well. It may also need more traits such as AsRef, AsMut, etc like
+// AccountId32 has.
+
+/// The account type to be used in Moonbeam. It is a wrapper for 20 fixed bytes. We prefer to use
+/// a dedicated type to prevent using arbitrary 20 byte arrays were AccountIds are expected. With
+/// the introduction of the `scale-info` crate this benefit extends even to non-Rust tools like
+/// Polkadot JS.
+
+#[derive(
+	Eq, PartialEq, Copy, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Default, PartialOrd, Ord,
+)]
+pub struct AccountId20(pub [u8; 20]);
+
+#[cfg(feature = "std")]
+impl_serde::impl_fixed_hash_serde!(AccountId20, 20);
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for AccountId20 {
+	//TODO This is a pretty quck-n-dirty implementation. Perhaps we should add
+	// checksum casing here? I bet there is a crate for that.
+	// Maybe this one https://github.com/miguelmota/rust-eth-checksum
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{:?}", self.0)
+	}
+}
+
+impl core::fmt::Debug for AccountId20 {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		write!(f, "{:?}", H160(self.0))
+	}
+}
+
+impl From<[u8; 20]> for AccountId20 {
+	fn from(bytes: [u8; 20]) -> Self {
+		Self(bytes)
+	}
+}
+
+impl Into<[u8; 20]> for AccountId20 {
+	fn into(self) -> [u8; 20] {
+		self.0
+	}
+}
+
+impl From<[u8; 32]> for AccountId20 {
+	fn from(bytes: [u8; 32]) -> Self {
+		let mut buffer = [0u8; 20];
+		buffer.copy_from_slice(&bytes[..20]);
+		Self(buffer)
+	}
+}
+
+impl From<H160> for AccountId20 {
+	fn from(h160: H160) -> Self {
+		Self(h160.0)
+	}
+}
+
+impl Into<H160> for AccountId20 {
+	fn into(self) -> H160 {
+		H160(self.0)
+	}
+}
+
+#[cfg(feature = "std")]
+impl std::str::FromStr for AccountId20 {
+	type Err = &'static str;
+	fn from_str(input: &str) -> Result<Self, Self::Err> {
+		H160::from_str(input)
+			.map(Into::into)
+			.map_err(|_| "invalid hex address.")
+	}
+}
+
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Eq, PartialEq, Clone, Encode, Decode, sp_core::RuntimeDebug, TypeInfo)]
+pub struct EthereumSignature(ecdsa::Signature);
+
+impl From<ecdsa::Signature> for EthereumSignature {
+	fn from(x: ecdsa::Signature) -> Self {
+		EthereumSignature(x)
+	}
+}
+
+impl sp_runtime::traits::Verify for EthereumSignature {
+	type Signer = EthereumSigner;
+	fn verify<L: sp_runtime::traits::Lazy<[u8]>>(&self, mut msg: L, signer: &AccountId20) -> bool {
+		let mut m = [0u8; 32];
+		m.copy_from_slice(Keccak256::digest(msg.get()).as_slice());
+		match sp_io::crypto::secp256k1_ecdsa_recover(self.0.as_ref(), &m) {
+			Ok(pubkey) => {
+				AccountId20(H160::from_slice(&Keccak256::digest(&pubkey).as_slice()[12..32]).0)
+					== *signer
+			}
+			Err(sp_io::EcdsaVerifyError::BadRS) => {
+				log::error!(target: "evm", "Error recovering: Incorrect value of R or S");
+				false
+			}
+			Err(sp_io::EcdsaVerifyError::BadV) => {
+				log::error!(target: "evm", "Error recovering: Incorrect value of V");
+				false
+			}
+			Err(sp_io::EcdsaVerifyError::BadSignature) => {
+				log::error!(target: "evm", "Error recovering: Invalid signature");
+				false
+			}
+		}
+	}
+}
+
+/// Public key for an Ethereum / Moonbeam compatible account
+#[derive(
+	Eq, PartialEq, Ord, PartialOrd, Clone, Encode, Decode, sp_core::RuntimeDebug, TypeInfo,
+)]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+pub struct EthereumSigner([u8; 20]);
+
+impl sp_runtime::traits::IdentifyAccount for EthereumSigner {
+	type AccountId = AccountId20;
+	fn into_account(self) -> AccountId20 {
+		AccountId20(self.0)
+	}
+}
+
+impl From<[u8; 20]> for EthereumSigner {
+	fn from(x: [u8; 20]) -> Self {
+		EthereumSigner(x)
+	}
+}
+
+impl From<ecdsa::Public> for EthereumSigner {
+	fn from(x: ecdsa::Public) -> Self {
+		let decompressed = libsecp256k1::PublicKey::parse_slice(
+			&x.0,
+			Some(libsecp256k1::PublicKeyFormat::Compressed),
+		)
+		.expect("Wrong compressed public key provided")
+		.serialize();
+		let mut m = [0u8; 64];
+		m.copy_from_slice(&decompressed[1..65]);
+		let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
+		EthereumSigner(account.into())
+	}
+}
+
+impl From<libsecp256k1::PublicKey> for EthereumSigner {
+	fn from(x: libsecp256k1::PublicKey) -> Self {
+		let mut m = [0u8; 64];
+		m.copy_from_slice(&x.serialize()[1..65]);
+		let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
+		EthereumSigner(account.into())
+	}
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for EthereumSigner {
+	fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(fmt, "ethereum signature: {:?}", H160::from_slice(&self.0))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sp_core::{ecdsa, Pair, H256};
+	use sp_runtime::traits::IdentifyAccount;
+
+	#[test]
+	fn test_account_derivation_1() {
+		// Test from https://asecuritysite.com/encryption/ethadd
+		let secret_key =
+			hex::decode("502f97299c472b88754accd412b7c9a6062ef3186fba0c0388365e1edec24875")
+				.unwrap();
+		let mut expected_hex_account = [0u8; 20];
+		hex::decode_to_slice(
+			"976f8456e4e2034179b284a23c0e0c8f6d3da50c",
+			&mut expected_hex_account,
+		)
+		.expect("example data is 20 bytes of valid hex");
+
+		let public_key = ecdsa::Pair::from_seed_slice(&secret_key).unwrap().public();
+		let account: EthereumSigner = public_key.into();
+		let expected_account = AccountId20::from(expected_hex_account);
+		assert_eq!(account.into_account(), expected_account);
+	}
+	#[test]
+	fn test_account_derivation_2() {
+		// Test from https://asecuritysite.com/encryption/ethadd
+		let secret_key =
+			hex::decode("0f02ba4d7f83e59eaa32eae9c3c4d99b68ce76decade21cdab7ecce8f4aef81a")
+				.unwrap();
+		let mut expected_hex_account = [0u8; 20];
+		hex::decode_to_slice(
+			"420e9f260b40af7e49440cead3069f8e82a5230f",
+			&mut expected_hex_account,
+		)
+		.expect("example data is 20 bytes of valid hex");
+
+		let public_key = ecdsa::Pair::from_seed_slice(&secret_key).unwrap().public();
+		let account: EthereumSigner = public_key.into();
+		let expected_account = AccountId20::from(expected_hex_account);
+		assert_eq!(account.into_account(), expected_account);
+	}
+	#[test]
+	fn test_account_derivation_3() {
+		let m = hex::decode("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+			.unwrap();
+		let old = AccountId20(H160::from(H256::from_slice(Keccak256::digest(&m).as_slice())).0);
+		let new = AccountId20(H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]).0);
+		assert_eq!(new, old);
+	}
+}

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -38,7 +38,7 @@ pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// Polkadot JS.
 
 #[derive(
-	Eq, PartialEq, Copy, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Default, PartialOrd, Ord,
+    Eq, PartialEq, Copy, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Default, PartialOrd, Ord,
 )]
 pub struct AccountId20(pub [u8; 20]);
 
@@ -47,60 +47,60 @@ impl_serde::impl_fixed_hash_serde!(AccountId20, 20);
 
 #[cfg(feature = "std")]
 impl std::fmt::Display for AccountId20 {
-	//TODO This is a pretty quck-n-dirty implementation. Perhaps we should add
-	// checksum casing here? I bet there is a crate for that.
-	// Maybe this one https://github.com/miguelmota/rust-eth-checksum
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{:?}", self.0)
-	}
+    //TODO This is a pretty quck-n-dirty implementation. Perhaps we should add
+    // checksum casing here? I bet there is a crate for that.
+    // Maybe this one https://github.com/miguelmota/rust-eth-checksum
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
 }
 
 impl core::fmt::Debug for AccountId20 {
-	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-		write!(f, "{:?}", H160(self.0))
-	}
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", H160(self.0))
+    }
 }
 
 impl From<[u8; 20]> for AccountId20 {
-	fn from(bytes: [u8; 20]) -> Self {
-		Self(bytes)
-	}
+    fn from(bytes: [u8; 20]) -> Self {
+        Self(bytes)
+    }
 }
 
 impl Into<[u8; 20]> for AccountId20 {
-	fn into(self) -> [u8; 20] {
-		self.0
-	}
+    fn into(self) -> [u8; 20] {
+        self.0
+    }
 }
 
 impl From<[u8; 32]> for AccountId20 {
-	fn from(bytes: [u8; 32]) -> Self {
-		let mut buffer = [0u8; 20];
-		buffer.copy_from_slice(&bytes[..20]);
-		Self(buffer)
-	}
+    fn from(bytes: [u8; 32]) -> Self {
+        let mut buffer = [0u8; 20];
+        buffer.copy_from_slice(&bytes[..20]);
+        Self(buffer)
+    }
 }
 
 impl From<H160> for AccountId20 {
-	fn from(h160: H160) -> Self {
-		Self(h160.0)
-	}
+    fn from(h160: H160) -> Self {
+        Self(h160.0)
+    }
 }
 
 impl Into<H160> for AccountId20 {
-	fn into(self) -> H160 {
-		H160(self.0)
-	}
+    fn into(self) -> H160 {
+        H160(self.0)
+    }
 }
 
 #[cfg(feature = "std")]
 impl std::str::FromStr for AccountId20 {
-	type Err = &'static str;
-	fn from_str(input: &str) -> Result<Self, Self::Err> {
-		H160::from_str(input)
-			.map(Into::into)
-			.map_err(|_| "invalid hex address.")
-	}
+    type Err = &'static str;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        H160::from_str(input)
+            .map(Into::into)
+            .map_err(|_| "invalid hex address.")
+    }
 }
 
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
@@ -108,136 +108,136 @@ impl std::str::FromStr for AccountId20 {
 pub struct EthereumSignature(ecdsa::Signature);
 
 impl From<ecdsa::Signature> for EthereumSignature {
-	fn from(x: ecdsa::Signature) -> Self {
-		EthereumSignature(x)
-	}
+    fn from(x: ecdsa::Signature) -> Self {
+        EthereumSignature(x)
+    }
 }
 
 impl sp_runtime::traits::Verify for EthereumSignature {
-	type Signer = EthereumSigner;
-	fn verify<L: sp_runtime::traits::Lazy<[u8]>>(&self, mut msg: L, signer: &AccountId20) -> bool {
-		let mut m = [0u8; 32];
-		m.copy_from_slice(Keccak256::digest(msg.get()).as_slice());
-		match sp_io::crypto::secp256k1_ecdsa_recover(self.0.as_ref(), &m) {
-			Ok(pubkey) => {
-				AccountId20(H160::from_slice(&Keccak256::digest(&pubkey).as_slice()[12..32]).0)
-					== *signer
-			}
-			Err(sp_io::EcdsaVerifyError::BadRS) => {
-				log::error!(target: "evm", "Error recovering: Incorrect value of R or S");
-				false
-			}
-			Err(sp_io::EcdsaVerifyError::BadV) => {
-				log::error!(target: "evm", "Error recovering: Incorrect value of V");
-				false
-			}
-			Err(sp_io::EcdsaVerifyError::BadSignature) => {
-				log::error!(target: "evm", "Error recovering: Invalid signature");
-				false
-			}
-		}
-	}
+    type Signer = EthereumSigner;
+    fn verify<L: sp_runtime::traits::Lazy<[u8]>>(&self, mut msg: L, signer: &AccountId20) -> bool {
+        let mut m = [0u8; 32];
+        m.copy_from_slice(Keccak256::digest(msg.get()).as_slice());
+        match sp_io::crypto::secp256k1_ecdsa_recover(self.0.as_ref(), &m) {
+            Ok(pubkey) => {
+                AccountId20(H160::from_slice(&Keccak256::digest(&pubkey).as_slice()[12..32]).0)
+                    == *signer
+            }
+            Err(sp_io::EcdsaVerifyError::BadRS) => {
+                log::error!(target: "evm", "Error recovering: Incorrect value of R or S");
+                false
+            }
+            Err(sp_io::EcdsaVerifyError::BadV) => {
+                log::error!(target: "evm", "Error recovering: Incorrect value of V");
+                false
+            }
+            Err(sp_io::EcdsaVerifyError::BadSignature) => {
+                log::error!(target: "evm", "Error recovering: Invalid signature");
+                false
+            }
+        }
+    }
 }
 
 /// Public key for an Ethereum / Moonbeam compatible account
 #[derive(
-	Eq, PartialEq, Ord, PartialOrd, Clone, Encode, Decode, sp_core::RuntimeDebug, TypeInfo,
+    Eq, PartialEq, Ord, PartialOrd, Clone, Encode, Decode, sp_core::RuntimeDebug, TypeInfo,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct EthereumSigner([u8; 20]);
 
 impl sp_runtime::traits::IdentifyAccount for EthereumSigner {
-	type AccountId = AccountId20;
-	fn into_account(self) -> AccountId20 {
-		AccountId20(self.0)
-	}
+    type AccountId = AccountId20;
+    fn into_account(self) -> AccountId20 {
+        AccountId20(self.0)
+    }
 }
 
 impl From<[u8; 20]> for EthereumSigner {
-	fn from(x: [u8; 20]) -> Self {
-		EthereumSigner(x)
-	}
+    fn from(x: [u8; 20]) -> Self {
+        EthereumSigner(x)
+    }
 }
 
 impl From<ecdsa::Public> for EthereumSigner {
-	fn from(x: ecdsa::Public) -> Self {
-		let decompressed = libsecp256k1::PublicKey::parse_slice(
-			&x.0,
-			Some(libsecp256k1::PublicKeyFormat::Compressed),
-		)
-		.expect("Wrong compressed public key provided")
-		.serialize();
-		let mut m = [0u8; 64];
-		m.copy_from_slice(&decompressed[1..65]);
-		let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
-		EthereumSigner(account.into())
-	}
+    fn from(x: ecdsa::Public) -> Self {
+        let decompressed = libsecp256k1::PublicKey::parse_slice(
+            &x.0,
+            Some(libsecp256k1::PublicKeyFormat::Compressed),
+        )
+        .expect("Wrong compressed public key provided")
+        .serialize();
+        let mut m = [0u8; 64];
+        m.copy_from_slice(&decompressed[1..65]);
+        let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
+        EthereumSigner(account.into())
+    }
 }
 
 impl From<libsecp256k1::PublicKey> for EthereumSigner {
-	fn from(x: libsecp256k1::PublicKey) -> Self {
-		let mut m = [0u8; 64];
-		m.copy_from_slice(&x.serialize()[1..65]);
-		let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
-		EthereumSigner(account.into())
-	}
+    fn from(x: libsecp256k1::PublicKey) -> Self {
+        let mut m = [0u8; 64];
+        m.copy_from_slice(&x.serialize()[1..65]);
+        let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
+        EthereumSigner(account.into())
+    }
 }
 
 #[cfg(feature = "std")]
 impl std::fmt::Display for EthereumSigner {
-	fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-		write!(fmt, "ethereum signature: {:?}", H160::from_slice(&self.0))
-	}
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(fmt, "ethereum signature: {:?}", H160::from_slice(&self.0))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use sp_core::{ecdsa, Pair, H256};
-	use sp_runtime::traits::IdentifyAccount;
+    use super::*;
+    use sp_core::{ecdsa, Pair, H256};
+    use sp_runtime::traits::IdentifyAccount;
 
-	#[test]
-	fn test_account_derivation_1() {
-		// Test from https://asecuritysite.com/encryption/ethadd
-		let secret_key =
-			hex::decode("502f97299c472b88754accd412b7c9a6062ef3186fba0c0388365e1edec24875")
-				.unwrap();
-		let mut expected_hex_account = [0u8; 20];
-		hex::decode_to_slice(
-			"976f8456e4e2034179b284a23c0e0c8f6d3da50c",
-			&mut expected_hex_account,
-		)
-		.expect("example data is 20 bytes of valid hex");
+    #[test]
+    fn test_account_derivation_1() {
+        // Test from https://asecuritysite.com/encryption/ethadd
+        let secret_key =
+            hex::decode("502f97299c472b88754accd412b7c9a6062ef3186fba0c0388365e1edec24875")
+                .unwrap();
+        let mut expected_hex_account = [0u8; 20];
+        hex::decode_to_slice(
+            "976f8456e4e2034179b284a23c0e0c8f6d3da50c",
+            &mut expected_hex_account,
+        )
+        .expect("example data is 20 bytes of valid hex");
 
-		let public_key = ecdsa::Pair::from_seed_slice(&secret_key).unwrap().public();
-		let account: EthereumSigner = public_key.into();
-		let expected_account = AccountId20::from(expected_hex_account);
-		assert_eq!(account.into_account(), expected_account);
-	}
-	#[test]
-	fn test_account_derivation_2() {
-		// Test from https://asecuritysite.com/encryption/ethadd
-		let secret_key =
-			hex::decode("0f02ba4d7f83e59eaa32eae9c3c4d99b68ce76decade21cdab7ecce8f4aef81a")
-				.unwrap();
-		let mut expected_hex_account = [0u8; 20];
-		hex::decode_to_slice(
-			"420e9f260b40af7e49440cead3069f8e82a5230f",
-			&mut expected_hex_account,
-		)
-		.expect("example data is 20 bytes of valid hex");
+        let public_key = ecdsa::Pair::from_seed_slice(&secret_key).unwrap().public();
+        let account: EthereumSigner = public_key.into();
+        let expected_account = AccountId20::from(expected_hex_account);
+        assert_eq!(account.into_account(), expected_account);
+    }
+    #[test]
+    fn test_account_derivation_2() {
+        // Test from https://asecuritysite.com/encryption/ethadd
+        let secret_key =
+            hex::decode("0f02ba4d7f83e59eaa32eae9c3c4d99b68ce76decade21cdab7ecce8f4aef81a")
+                .unwrap();
+        let mut expected_hex_account = [0u8; 20];
+        hex::decode_to_slice(
+            "420e9f260b40af7e49440cead3069f8e82a5230f",
+            &mut expected_hex_account,
+        )
+        .expect("example data is 20 bytes of valid hex");
 
-		let public_key = ecdsa::Pair::from_seed_slice(&secret_key).unwrap().public();
-		let account: EthereumSigner = public_key.into();
-		let expected_account = AccountId20::from(expected_hex_account);
-		assert_eq!(account.into_account(), expected_account);
-	}
-	#[test]
-	fn test_account_derivation_3() {
-		let m = hex::decode("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
-			.unwrap();
-		let old = AccountId20(H160::from(H256::from_slice(Keccak256::digest(&m).as_slice())).0);
-		let new = AccountId20(H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]).0);
-		assert_eq!(new, old);
-	}
+        let public_key = ecdsa::Pair::from_seed_slice(&secret_key).unwrap().public();
+        let account: EthereumSigner = public_key.into();
+        let expected_account = AccountId20::from(expected_hex_account);
+        assert_eq!(account.into_account(), expected_account);
+    }
+    #[test]
+    fn test_account_derivation_3() {
+        let m = hex::decode("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+            .unwrap();
+        let old = AccountId20(H160::from(H256::from_slice(Keccak256::digest(&m).as_slice())).0);
+        let new = AccountId20(H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]).0);
+        assert_eq!(new, old);
+    }
 }

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -67,9 +67,9 @@ impl From<[u8; 20]> for AccountId20 {
     }
 }
 
-impl Into<[u8; 20]> for AccountId20 {
-    fn into(self) -> [u8; 20] {
-        self.0
+impl From<AccountId20> for [u8; 20] {
+    fn from(value: AccountId20) -> Self {
+        value.0
     }
 }
 
@@ -87,9 +87,9 @@ impl From<H160> for AccountId20 {
     }
 }
 
-impl Into<H160> for AccountId20 {
-    fn into(self) -> H160 {
-        H160(self.0)
+impl From<AccountId20> for H160 {
+    fn from(value: AccountId20) -> Self {
+        H160(value.0)
     }
 }
 
@@ -120,7 +120,7 @@ impl sp_runtime::traits::Verify for EthereumSignature {
         m.copy_from_slice(Keccak256::digest(msg.get()).as_slice());
         match sp_io::crypto::secp256k1_ecdsa_recover(self.0.as_ref(), &m) {
             Ok(pubkey) => {
-                AccountId20(H160::from_slice(&Keccak256::digest(&pubkey).as_slice()[12..32]).0)
+                AccountId20(H160::from_slice(&Keccak256::digest(pubkey).as_slice()[12..32]).0)
                     == *signer
             }
             Err(sp_io::EcdsaVerifyError::BadRS) => {
@@ -169,7 +169,7 @@ impl From<ecdsa::Public> for EthereumSigner {
         .serialize();
         let mut m = [0u8; 64];
         m.copy_from_slice(&decompressed[1..65]);
-        let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
+        let account = H160::from_slice(&Keccak256::digest(m).as_slice()[12..32]);
         EthereumSigner(account.into())
     }
 }
@@ -178,7 +178,7 @@ impl From<libsecp256k1::PublicKey> for EthereumSigner {
     fn from(x: libsecp256k1::PublicKey) -> Self {
         let mut m = [0u8; 64];
         m.copy_from_slice(&x.serialize()[1..65]);
-        let account = H160::from_slice(&Keccak256::digest(&m).as_slice()[12..32]);
+        let account = H160::from_slice(&Keccak256::digest(m).as_slice()[12..32]);
         EthereumSigner(account.into())
     }
 }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.3.0", features = ["derive"] }
 parity-scale-codec = '3.1.2'
 sha3 = "0.10.1"
 rand = { version = "0.8.5", features = ["small_rng"] }
+hex-literal = "0.4.1"
 
 account = { path = "../account" }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,6 +20,8 @@ parity-scale-codec = '3.1.2'
 sha3 = "0.10.1"
 rand = { version = "0.8.5", features = ["small_rng"] }
 
+account = { path = "../account" }
+
 # These dependencies are used for the node template's RPCs
 jsonrpsee = { version = "0.16.0", features = ["server"] }
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -2,9 +2,9 @@ use academy_pow_runtime::{
     AccountId, BalancesConfig, DifficultyAdjustmentConfig, GenesisConfig, Signature, SystemConfig,
     WASM_BINARY,
 };
+use hex_literal::hex;
 use sp_core::{ecdsa, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
-use hex_literal::hex;
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig>;

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -4,6 +4,7 @@ use academy_pow_runtime::{
 };
 use sp_core::{ecdsa, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
+use hex_literal::hex;
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig>;
@@ -37,6 +38,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
                 wasm_binary,
                 vec![
                     get_account_id_from_seed::<ecdsa::Public>("Alice"),
+                    AccountId::from(hex!("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac")),
                     get_account_id_from_seed::<ecdsa::Public>("Bob"),
                     get_account_id_from_seed::<ecdsa::Public>("Alice//stash"),
                     get_account_id_from_seed::<ecdsa::Public>("Bob//stash"),

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -2,7 +2,7 @@ use academy_pow_runtime::{
     AccountId, BalancesConfig, DifficultyAdjustmentConfig, GenesisConfig, Signature, SystemConfig,
     WASM_BINARY,
 };
-use sp_core::{sr25519, Pair, Public};
+use sp_core::{ecdsa, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
@@ -36,10 +36,10 @@ pub fn development_config() -> Result<ChainSpec, String> {
             genesis(
                 wasm_binary,
                 vec![
-                    get_account_id_from_seed::<sr25519::Public>("Alice"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob"),
-                    get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+                    get_account_id_from_seed::<ecdsa::Public>("Alice"),
+                    get_account_id_from_seed::<ecdsa::Public>("Bob"),
+                    get_account_id_from_seed::<ecdsa::Public>("Alice//stash"),
+                    get_account_id_from_seed::<ecdsa::Public>("Bob//stash"),
                 ],
                 4_000_000,
             )
@@ -64,18 +64,18 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
             genesis(
                 wasm_binary,
                 vec![
-                    get_account_id_from_seed::<sr25519::Public>("Alice"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob"),
-                    get_account_id_from_seed::<sr25519::Public>("Charlie"),
-                    get_account_id_from_seed::<sr25519::Public>("Dave"),
-                    get_account_id_from_seed::<sr25519::Public>("Eve"),
-                    get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-                    get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+                    get_account_id_from_seed::<ecdsa::Public>("Alice"),
+                    get_account_id_from_seed::<ecdsa::Public>("Bob"),
+                    get_account_id_from_seed::<ecdsa::Public>("Charlie"),
+                    get_account_id_from_seed::<ecdsa::Public>("Dave"),
+                    get_account_id_from_seed::<ecdsa::Public>("Eve"),
+                    get_account_id_from_seed::<ecdsa::Public>("Ferdie"),
+                    get_account_id_from_seed::<ecdsa::Public>("Alice//stash"),
+                    get_account_id_from_seed::<ecdsa::Public>("Bob//stash"),
+                    get_account_id_from_seed::<ecdsa::Public>("Charlie//stash"),
+                    get_account_id_from_seed::<ecdsa::Public>("Dave//stash"),
+                    get_account_id_from_seed::<ecdsa::Public>("Eve//stash"),
+                    get_account_id_from_seed::<ecdsa::Public>("Ferdie//stash"),
                 ],
                 4_000_000,
             )

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -57,7 +57,11 @@ fn parse_chaintype(s: &str) -> Result<ChainType, String> {
 /// Parse AccountId from a string argument passed on the command line.
 fn parse_account_id(s: &str) -> Result<AccountId, String> {
     // Handle the optional 0x prefix
-    let s = if s.starts_with("0x") { &s[2..] } else { &s[..] };
+    let s = if let Some(stripped) = s.strip_prefix("0x") {
+        stripped
+    } else {
+        s
+    };
 
     // Decode the hex.
     let v = hex::decode(s).map_err(|_| "Could not decode account id as hex")?;
@@ -67,9 +71,7 @@ fn parse_account_id(s: &str) -> Result<AccountId, String> {
 
     // Isn't there a method to cast to a fixed length array?
     let mut bytes = [0u8; 20];
-    for i in 0..20 {
-        bytes[i] = v[i];
-    }
+    bytes[..20].copy_from_slice(&v[..20]);
 
     Ok(AccountId::from(bytes))
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -18,8 +18,8 @@ pub struct Cli {
     pub instant_seal: bool,
 
     /// Miner's AccountId (base58 encoding of an SR25519 public key) for the block rewards
-    #[clap(long, value_parser = parse_account_id)]
-    pub mining_account_id: Option<AccountId>,
+    #[clap(long, value_parser = parse_account_id, default_value = "0000000000000000000000000000000000000000")]
+    pub mining_account_id: AccountId,
 
     #[clap(flatten)]
     pub run: RunCmd,

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,11 +1,9 @@
 use academy_pow_runtime::AccountId;
 use sc_cli::{
-    clap::{ArgGroup, Parser},
+    clap::Parser,
     RunCmd,
 };
 use sc_service::ChainType;
-use sp_core::crypto::Ss58Codec;
-use sp_core::sr25519;
 
 #[derive(Debug, Parser)]
 #[clap(subcommand_negates_reqs(true), version(env!("SUBSTRATE_CLI_IMPL_VERSION")))]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -83,12 +83,6 @@ fn parse_account_id(s: &str) -> Result<AccountId, String> {
     Ok(AccountId::from(bytes))
 }
 
-/// Parse sr25519 pubkey from a string argument passed on the command line.
-fn parse_sr25519_public_key(s: &str) -> Result<sr25519::Public, String> {
-    Ok(sr25519::Public::from_string(s)
-        .expect("Passed string is not a hex encoding of a sr25519 public key"))
-}
-
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommand {
     /// Key management cli utilities

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,8 +1,5 @@
 use academy_pow_runtime::AccountId;
-use sc_cli::{
-    clap::Parser,
-    RunCmd,
-};
+use sc_cli::{clap::Parser, RunCmd};
 use sc_service::ChainType;
 
 #[derive(Debug, Parser)]
@@ -60,11 +57,7 @@ fn parse_chaintype(s: &str) -> Result<ChainType, String> {
 /// Parse AccountId from a string argument passed on the command line.
 fn parse_account_id(s: &str) -> Result<AccountId, String> {
     // Handle the optional 0x prefix
-    let s = if s.starts_with("0x") {
-        &s[2..]
-    } else {
-        &s[..]
-    };
+    let s = if s.starts_with("0x") { &s[2..] } else { &s[..] };
 
     // Decode the hex.
     let v = hex::decode(s).map_err(|_| "Could not decode account id as hex")?;

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -17,7 +17,6 @@
 use academy_pow_runtime::Block;
 use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
-use sp_core::sr25519::Public;
 
 use crate::{
     chain_spec,

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -168,12 +168,9 @@ pub fn run() -> sc_cli::Result<()> {
             runner.sync_run(|config| cmd.run::<Block>(&config))
         }
         None => {
-            let bytes: [u8; 32] = cli.pow.public_key_bytes();
-            let sr25519_public_key = Public(bytes);
-
             let runner = cli.create_runner(&cli.run)?;
             runner.run_node_until_exit(|config| async move {
-                service::new_full(config, sr25519_public_key, cli.pow.instant_seal)
+                service::new_full(config, cli.mining_account_id, cli.instant_seal)
                     .map_err(sc_cli::Error::Service)
             })
         }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1,6 +1,7 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
 use academy_pow_runtime::{self, opaque::Block, RuntimeApi};
+use account::AccountId20;
 use core::clone::Clone;
 use parity_scale_codec::Encode;
 use sc_consensus::LongestChain;
@@ -10,7 +11,6 @@ use sc_telemetry::{Telemetry, TelemetryWorker};
 use sha3pow::Sha3Algorithm;
 use sp_api::TransactionFor;
 use std::sync::Arc;
-use account::AccountId20;
 
 // Our native executor instance.
 pub struct ExecutorDispatch;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -149,10 +149,10 @@ pub fn build_pow_import_queue(
             let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
 
             // We don't need the current mining key to check inherents, so we just use a default.
-            let author =
-                academy_pow_runtime::block_author::InherentDataProvider(Default::default());
+            // let author =
+            //     academy_pow_runtime::block_author::InherentDataProvider(Default::default());
 
-            Ok((timestamp, author))
+            Ok((timestamp/*, author*/))
         },
     );
 
@@ -277,11 +277,11 @@ pub fn new_full(
                 move |_, ()| async move {
                     let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
 
-                    let author = academy_pow_runtime::block_author::InherentDataProvider(
-                        sr25519_public_key.encode(),
-                    );
+                    // let author = academy_pow_runtime::block_author::InherentDataProvider(
+                    //     sr25519_public_key.encode(),
+                    // );
 
-                    Ok((timestamp, author))
+                    Ok((timestamp/*, author*/))
                 },
                 std::time::Duration::from_secs(10),
                 std::time::Duration::from_secs(5),

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -9,8 +9,8 @@ use sc_service::{error::Error as ServiceError, Configuration, PartialComponents,
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sha3pow::Sha3Algorithm;
 use sp_api::TransactionFor;
-use sp_core::sr25519;
 use std::sync::Arc;
+use account::AccountId20;
 
 // Our native executor instance.
 pub struct ExecutorDispatch;
@@ -170,7 +170,7 @@ pub fn build_pow_import_queue(
 /// Builds a new service for a full client.
 pub fn new_full(
     config: Configuration,
-    sr25519_public_key: sr25519::Public,
+    mining_account_id: AccountId20,
     instant_seal: bool,
 ) -> Result<TaskManager, ServiceError> {
     let build_import_queue = if instant_seal {
@@ -278,7 +278,7 @@ pub fn new_full(
                     let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
 
                     // let author = academy_pow_runtime::block_author::InherentDataProvider(
-                    //     sr25519_public_key.encode(),
+                    //     mining_account_id.encode(),
                     // );
 
                     Ok((timestamp/*, author*/))

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -149,10 +149,10 @@ pub fn build_pow_import_queue(
             let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
 
             // We don't need the current mining key to check inherents, so we just use a default.
-            // let author =
-            //     academy_pow_runtime::block_author::InherentDataProvider(Default::default());
+            let author =
+                academy_pow_runtime::block_author::InherentDataProvider(Default::default());
 
-            Ok((timestamp/*, author*/))
+            Ok((timestamp, author))
         },
     );
 
@@ -277,11 +277,11 @@ pub fn new_full(
                 move |_, ()| async move {
                     let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
 
-                    // let author = academy_pow_runtime::block_author::InherentDataProvider(
-                    //     mining_account_id.encode(),
-                    // );
+                    let author = academy_pow_runtime::block_author::InherentDataProvider(
+                        mining_account_id.encode(),
+                    );
 
-                    Ok((timestamp/*, author*/))
+                    Ok((timestamp, author))
                 },
                 std::time::Duration::from_secs(10),
                 std::time::Duration::from_secs(5),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,6 +11,8 @@ scale-info = { version = "2.1.2", default-features = false, features = ["derive"
 serde = { version = '1.0.137', optional = true }
 async-trait = { version = '0.1.53', optional = true }
 
+account = { path = "../account", default-features = false}
+
 
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-sudo = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
@@ -50,6 +52,7 @@ substrate-wasm-builder = { default-features = false, git = "https://github.com/p
 [features]
 default = ['std']
 std = [
+    'account/std',
     'pallet-balances/std',
     'parity-scale-codec/std',
     'frame-executive/std',

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -41,7 +41,7 @@ use sp_runtime::{
         AccountIdLookup, BlakeTwo256, Block as BlockT, Bounded, IdentifyAccount, One, Verify,
     },
     transaction_validity::{TransactionSource, TransactionValidity},
-    ApplyExtrinsicResult, MultiSignature,
+    ApplyExtrinsicResult,
 };
 pub use sp_runtime::{FixedPointNumber, Perbill, Permill};
 use sp_std::prelude::*;
@@ -71,8 +71,8 @@ pub type Index = u32;
 /// A hash of some data used by the chain.
 pub type Hash = sp_core::H256;
 
-/// The BlockAuthor trait in `./block_author.rs`
-pub mod block_author;
+// /// The BlockAuthor trait in `./block_author.rs`
+// pub mod block_author;
 
 /// The Issuance trait in `./issuance.rs`
 pub mod issuance;
@@ -252,16 +252,16 @@ impl faucet::Config for Runtime {
     type DripAmount = ConstU128<{ 5 * TOKEN }>;
 }
 
-impl block_author::Config for Runtime {
-    // Issue some new tokens to the block author
-    fn on_author_set(author_account: Self::AccountId) {
-        let block = System::block_number();
-        let issuance =
-            <issuance::BitcoinHalving as Issuance<BlockNumber, Balance>>::issuance(block);
-        let issuance = issuance * TOKEN;
-        let _ = Balances::deposit_creating(&author_account, issuance);
-    }
-}
+// impl block_author::Config for Runtime {
+//     // Issue some new tokens to the block author
+//     fn on_author_set(author_account: Self::AccountId) {
+//         let block = System::block_number();
+//         let issuance =
+//             <issuance::BitcoinHalving as Issuance<BlockNumber, Balance>>::issuance(block);
+//         let issuance = issuance * TOKEN;
+//         let _ = Balances::deposit_creating(&author_account, issuance);
+//     }
+// }
 
 parameter_types! {
     // This value increases the priority of `Operational` transactions by adding
@@ -349,7 +349,7 @@ construct_runtime!(
         // Sudo: pallet_sudo
         TransactionPayment: pallet_transaction_payment,
         DifficultyAdjustment: difficulty,
-        BlockAuthor: block_author,
+        // BlockAuthor: block_author,
         Faucet: faucet,
         Contracts: pallet_contracts,
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -102,8 +102,8 @@ pub mod opaque {
 
 /// This runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-    spec_name: create_runtime_str!("academy-pow"),
-    impl_name: create_runtime_str!("academy-pow"),
+    spec_name: create_runtime_str!("frontier-template"),
+    impl_name: create_runtime_str!("frontier-template"),
     authoring_version: 1,
     spec_version: 1,
     impl_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -41,7 +41,7 @@ use sp_runtime::{
         AccountIdLookup, BlakeTwo256, Block as BlockT, Bounded, IdentifyAccount, One, Verify,
     },
     transaction_validity::{TransactionSource, TransactionValidity},
-    ApplyExtrinsicResult,
+    ApplyExtrinsicResult, MultiSignature,
 };
 pub use sp_runtime::{FixedPointNumber, Perbill, Permill};
 use sp_std::prelude::*;
@@ -71,8 +71,8 @@ pub type Index = u32;
 /// A hash of some data used by the chain.
 pub type Hash = sp_core::H256;
 
-// /// The BlockAuthor trait in `./block_author.rs`
-// pub mod block_author;
+/// The BlockAuthor trait in `./block_author.rs`
+pub mod block_author;
 
 /// The Issuance trait in `./issuance.rs`
 pub mod issuance;
@@ -252,16 +252,16 @@ impl faucet::Config for Runtime {
     type DripAmount = ConstU128<{ 5 * TOKEN }>;
 }
 
-// impl block_author::Config for Runtime {
-//     // Issue some new tokens to the block author
-//     fn on_author_set(author_account: Self::AccountId) {
-//         let block = System::block_number();
-//         let issuance =
-//             <issuance::BitcoinHalving as Issuance<BlockNumber, Balance>>::issuance(block);
-//         let issuance = issuance * TOKEN;
-//         let _ = Balances::deposit_creating(&author_account, issuance);
-//     }
-// }
+impl block_author::Config for Runtime {
+    // Issue some new tokens to the block author
+    fn on_author_set(author_account: Self::AccountId) {
+        let block = System::block_number();
+        let issuance =
+            <issuance::BitcoinHalving as Issuance<BlockNumber, Balance>>::issuance(block);
+        let issuance = issuance * TOKEN;
+        let _ = Balances::deposit_creating(&author_account, issuance);
+    }
+}
 
 parameter_types! {
     // This value increases the priority of `Operational` transactions by adding
@@ -349,7 +349,7 @@ construct_runtime!(
         // Sudo: pallet_sudo
         TransactionPayment: pallet_transaction_payment,
         DifficultyAdjustment: difficulty,
-        // BlockAuthor: block_author,
+        BlockAuthor: block_author,
         Faucet: faucet,
         Contracts: pallet_contracts,
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -52,7 +52,7 @@ use sp_version::RuntimeVersion;
 pub type BlockNumber = u32;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
-pub type Signature = MultiSignature;
+pub type Signature = account::EthereumSignature;
 
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -38,7 +38,7 @@ pub use sp_runtime::BuildStorage;
 use sp_runtime::{
     create_runtime_str, generic,
     traits::{
-        AccountIdLookup, BlakeTwo256, Block as BlockT, Bounded, IdentifyAccount, One, Verify,
+        BlakeTwo256, Block as BlockT, Bounded, IdentifyAccount, One, Verify,
     },
     transaction_validity::{TransactionSource, TransactionValidity},
     ApplyExtrinsicResult,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -37,9 +37,7 @@ use sp_core::{OpaqueMetadata, U256};
 pub use sp_runtime::BuildStorage;
 use sp_runtime::{
     create_runtime_str, generic,
-    traits::{
-        BlakeTwo256, Block as BlockT, Bounded, IdentifyAccount, One, Verify,
-    },
+    traits::{BlakeTwo256, Block as BlockT, Bounded, IdentifyAccount, One, Verify},
     transaction_validity::{TransactionSource, TransactionValidity},
     ApplyExtrinsicResult,
 };

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -152,7 +152,7 @@ impl frame_system::Config for Runtime {
     /// The aggregated dispatch type that is available for extrinsics.
     type RuntimeCall = RuntimeCall;
     /// The lookup mechanism to get account ID from whatever is passed in dispatchers.
-    type Lookup = AccountIdLookup<AccountId, ()>;
+    type Lookup = sp_runtime::traits::IdentityLookup<AccountId>;
     /// The index type for storing how many extrinsics an account has signed.
     type Index = Index;
     /// The index type for blocks.
@@ -356,7 +356,7 @@ construct_runtime!(
 );
 
 /// The address format for describing accounts.
-pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
+pub type Address = AccountId;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -41,7 +41,7 @@ use sp_runtime::{
         AccountIdLookup, BlakeTwo256, Block as BlockT, Bounded, IdentifyAccount, One, Verify,
     },
     transaction_validity::{TransactionSource, TransactionValidity},
-    ApplyExtrinsicResult, MultiSignature,
+    ApplyExtrinsicResult,
 };
 pub use sp_runtime::{FixedPointNumber, Perbill, Permill};
 use sp_std::prelude::*;

--- a/scripts/bootstrap_chain.sh
+++ b/scripts/bootstrap_chain.sh
@@ -7,9 +7,9 @@ set -eo pipefail
 
 export NODE_IMAGE=academy-pow-node:latest
 export BASE_PATH=/tmp/academy-pow
-export ALICE=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-export BOB=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
-export EVE=5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw
+export ALICE=0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac
+export BOB=0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0
+export EVE=0xFf64d3F6efE2317EE2807d223a0Bdc4c0c49dfDB
 
 # --- FUNCTIONS
 


### PR DESCRIPTION
This PR switches the chain's native account id type to be `AccountId20` which is the same one Moonbeam uses.

This is in preparation for evm support in #9. The evm _requires_ eth-style account ids, and if we can use the same ones in the runtime, then we don't have the make users map them together and handle the corresponding edge cases.