### PR TITLE
Eth-like tokens

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -3,9 +3,20 @@ use academy_pow_runtime::{
     SystemConfig, WASM_BINARY,
 };
 use hex_literal::hex;
+use sc_telemetry::serde_json;
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig>;
+
+/// Returns the chain spec properties for Academy Pow networks
+pub fn spec_properties() -> serde_json::map::Map<String, serde_json::Value> {
+	serde_json::json!({
+		"tokenDecimals": 18,
+	})
+	.as_object()
+	.expect("Map given; qed")
+	.clone()
+}
 
 pub fn development_config() -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
@@ -28,7 +39,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
         None,
         None,
         None,
-        None,
+        Some(spec_properties()),
         None,
     ))
 }
@@ -54,7 +65,7 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
         None,
         None,
         None,
-        None,
+        Some(spec_properties()),
         None,
     ))
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -105,7 +105,7 @@ fn genesis(
             balances: endowed_accounts
                 .iter()
                 .cloned()
-                .map(|k| (k, 1 << 60))
+                .map(|k| (k, 1 << 65))
                 .collect(),
         },
         // sudo: SudoConfig {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -242,7 +242,7 @@ impl pallet_balances::Config for Runtime {
     /// The ubiquitous event type.
     type RuntimeEvent = RuntimeEvent;
     type DustRemoval = ();
-    type ExistentialDeposit = ConstU128<500>;
+    type ExistentialDeposit = ConstU128<0>;
     type AccountStore = System;
     type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
     type FreezeIdentifier = ();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -152,7 +152,7 @@ pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
 );
 
 // native chain currency
-pub const TOKEN_DECIMALS: u32 = 12;
+pub const TOKEN_DECIMALS: u32 = 18;
 pub const TOKEN: u128 = 10u128.pow(TOKEN_DECIMALS);
 
 parameter_types! {


### PR DESCRIPTION
This PR changes the number of token decimals to 18 so tools like metamask are not confused. Correspondingly,it increases the endowment so that the initial balances are still reasonable.

Finally, it sets the existential balance to zero so that contracts are not reaped.