### PR TITLE
fix: set system_properties to provide prefix/symbol/decimals config to dapps & wallets

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,6 +1,9 @@
 use std::str::FromStr;
 
-use academy_pow_runtime::{AccountId, RuntimeGenesisConfig, Signature, WASM_BINARY};
+use academy_pow_runtime::{
+    AccountId, RuntimeGenesisConfig, SS58Prefix, Signature, TOKEN_DECIMALS, TOKEN_SYMBOL,
+    WASM_BINARY,
+};
 use multi_pow::{ForkHeights, ForkingConfig, MaxiPosition};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
@@ -108,6 +111,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
         // Initial Difficulty
         4_000_000,
     ))
+    .with_properties(system_properties())
     .build())
 }
 
@@ -132,6 +136,7 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
         ],
         4_000_000,
     ))
+    .with_properties(system_properties())
     .build())
 }
 
@@ -146,4 +151,14 @@ fn genesis(endowed_accounts: Vec<AccountId>, _initial_difficulty: u32) -> serde_
         //     "initialDifficulty": serde_json::json!(initial_difficulty),
         // },
     })
+}
+
+fn system_properties() -> sc_chain_spec::Properties {
+    let mut properties = sc_chain_spec::Properties::new();
+
+    properties.insert("ss58Format".into(), SS58Prefix::get().into());
+    properties.insert("tokenSymbol".into(), TOKEN_SYMBOL.into());
+    properties.insert("tokenDecimals".into(), TOKEN_DECIMALS.into());
+
+    properties
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -129,6 +129,7 @@ pub fn native_version() -> NativeVersion {
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 // native chain currency
+pub const TOKEN_SYMBOL: &str = "Unit";
 pub const TOKEN_DECIMALS: u32 = 12;
 pub const TOKEN: u128 = 10u128.pow(TOKEN_DECIMALS);
 


### PR DESCRIPTION
Yo!

The `system_properties` RPC call is the standard way for dapps & wallets to find out what these values are set to for each substrate chain.

By chance, the setting of `12` for decimals and `42` for the account prefix are the defaults shown in the metadata section of the [polkadot.js apps UI](https://polkadot.js.org/apps/).  
As such, when using that UI it looks like it has successfully picked up the `TOKEN_DECIMALS` value from the config for this chain.

In reality, if a dev were to change the decimals to e.g. `18` or `10`, they might be confused to find that pjs-apps still considers it to be `12`!

Also in Talisman, when a user-provided chain RPC doesn't tell us otherwise, we use `0` as a default for decimals because we don't want our users to accidentally transfer significantly more tokens than they intended to, on account of a missing piece of chain configuration.

By merging this PR, both scenarios will be accounted for 🙂
Pjs-apps and Talisman will both use the correct token decimals, as configured in `lib.rs`.