### PR TITLE
Add block author to pre-runtime digest

### DIFF
--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -3,7 +3,7 @@
 use core::clone::Clone;
 use std::sync::Arc;
 
-use academy_pow_runtime::{self, opaque::Block, RuntimeApi};
+use academy_pow_runtime::{self, opaque::Block, PreDigest, RuntimeApi};
 use multi_pow::{ForkingConfig, MultiPow, SupportedHashes};
 use parity_scale_codec::Encode;
 use sc_consensus::LongestChain;
@@ -238,7 +238,7 @@ pub fn new_full(
                 // This allows us to know which algo it was in the runtime.
                 // TODO This also makes it possible to remove the algo info from
                 // the seal.
-                Some(mining_algo.encode()),
+                Some(PreDigest::from((sr25519_public_key.into(), mining_algo)).encode()),
                 // This code is copied from above. Would be better to not repeat it.
                 move |_, ()| async move {
                     let timestamp = sp_timestamp::InherentDataProvider::from_system_time();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -79,6 +79,9 @@ pub type Index = u32;
 /// A hash of some data used by the chain.
 pub type Hash = sp_core::H256;
 
+/// Consensus digest containing block author and supported hash algorithm.
+pub type PreDigest = (AccountId, SupportedHashes);
+
 /// The BlockAuthor trait in `./block_author.rs`
 pub mod block_author;
 
@@ -239,7 +242,8 @@ fn current_blocks_mining_algo() -> SupportedHashes {
         .iter()
         .find_map(|digest_item| {
             match digest_item {
-                DigestItem::PreRuntime(POW_ENGINE_ID, encoded_algo) => SupportedHashes::decode(&mut &encoded_algo[..]).ok(),
+                DigestItem::PreRuntime(POW_ENGINE_ID, pre_digest) =>
+                    PreDigest::decode(&mut &pre_digest[..]).map(|d| d.1).ok(),
                 _ => None,
             }
         })


### PR DESCRIPTION
This PR adds block author to pre-runtime digest to display who authored the given block on explorer like `polkadot.js.org/apps`.