### PR TITLE
Allow dev accounts to be used as miners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "sp-consensus-pow",
  "sp-core",
  "sp-inherents",
+ "sp-keyring",
  "sp-runtime",
  "sp-timestamp",
  "sp-transaction-pool",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ sp-core = { branch = "release-polkadot-v1.5.0", default-features = false, git = 
 sp-genesis-builder = { branch = "release-polkadot-v1.5.0", default-features = false, git = "https://github.com/paritytech/polkadot-sdk" }
 sp-inherents = { branch = "release-polkadot-v1.5.0", default-features = false, git = "https://github.com/paritytech/polkadot-sdk" }
 sp-io = { branch = "release-polkadot-v1.5.0", default-features = false, git = "https://github.com/paritytech/polkadot-sdk" }
+sp-keyring = { branch = "release-polkadot-v1.5.0", git = "https://github.com/paritytech/polkadot-sdk" }
 sp-keystore = { branch = "release-polkadot-v1.5.0", git = "https://github.com/paritytech/polkadot-sdk" }
 sp-offchain = { branch = "release-polkadot-v1.5.0", default-features = false, git = "https://github.com/paritytech/polkadot-sdk" }
 sp-runtime = { branch = "release-polkadot-v1.5.0", default-features = false, git = "https://github.com/paritytech/polkadot-sdk" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -45,6 +45,7 @@ sp-consensus = { workspace = true }
 sp-consensus-pow = { workspace = true }
 sp-core = { workspace = true }
 sp-inherents = { workspace = true }
+sp-keyring = { workspace = true }
 sp-runtime = { workspace = true }
 sp-timestamp = { workspace = true }
 sp-transaction-pool = { workspace = true }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -47,12 +47,12 @@ pub struct AcademyPowCli {
 }
 
 impl AcademyPowCli {
-    pub fn public_key_bytes(&self) -> [u8; 32] {
+    pub fn public_key_bytes(&self, keyring: Option<sp_keyring::Sr25519Keyring>) -> [u8; 32] {
         match &self.mining_account_id {
             Some(account_id) => *account_id.as_ref(),
             None => match self.mining_public_key {
                 Some(public_key) => public_key.0,
-                None => [0u8; 32],
+                None => keyring.map(|k| k.to_raw_public()).unwrap_or([0u8; 32]),
             },
         }
     }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -147,7 +147,7 @@ pub fn run() -> sc_cli::Result<()> {
         }
         None => {
             // Get the mining account from the cli
-            let bytes: [u8; 32] = cli.pow.public_key_bytes();
+            let bytes: [u8; 32] = cli.pow.public_key_bytes(cli.run.get_keyring());
             let sr25519_public_key = Public(bytes);
 
             let runner = cli.create_runner(&cli.run)?;


### PR DESCRIPTION
This PR makes CLI options (like `--alice`, `--bob`) set miner to dev accounts unless either `--mining-account-id` or `--mining-public-key` is explicitly set.